### PR TITLE
Switch back to using internal stream pump

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const peer = require('noise-peer')
 const protocol = require('rpc-protocol')
-const pump = require('pump')
 
 /**
  * createSecureRPC returns an rpc-protocol instance connected over a secure socket.
@@ -13,16 +12,8 @@ const pump = require('pump')
 function createSecureRPC (stream, isInitiator, opts = {}) {
   const { encoding, ...rest } = opts
   const sec = peer(stream, isInitiator, rest)
-  const rpc = protocol({ encoding })
+  const rpc = protocol({ stream: sec, encoding })
   rpc.sec = sec
-
-  // Important detail:
-  // internally, rpc will perform pump(rpc, sec, rpc). We must
-  // call pump(sec, rpc, sec) instead.  It should be the same but it isn't.
-  //
-  // Using the built in stream option for rpc results in finish messages
-  // not properly propagating from both ends.
-  pump(sec, rpc, sec)
 
   return rpc
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "noise-peer": "^1.1.0",
-    "pump": "^3.0.0",
     "rpc-protocol": "^0.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This depends on https://github.com/little-core-labs/rpc-protocol/pull/4

If that ends up landing, we can land this as well.